### PR TITLE
Allow direct access using an access token, supports the scenario where a webserver needs to call the function directly

### DIFF
--- a/src/shortenerTools/UrlArchive/UrlArchive.cs
+++ b/src/shortenerTools/UrlArchive/UrlArchive.cs
@@ -57,7 +57,7 @@ namespace Cloud5mins.Function
             ShortUrlEntity result;
             try
             {
-                var invalidRequest = Utility.CatchUnauthorize(principal, log);
+                var invalidRequest = Utility.CheckUserImpersonatedAuth(principal, log);
                 if (invalidRequest != null)
                 {
                     return invalidRequest;

--- a/src/shortenerTools/UrlClickStats/UrlClickStats.cs
+++ b/src/shortenerTools/UrlClickStats/UrlClickStats.cs
@@ -30,7 +30,7 @@ namespace Cloud5mins.Function
             UrlClickStatsRequest input;
             var result = new ClickStatsEntityList();
 
-            var invalidRequest = Utility.CatchUnauthorize(principal, log);
+            var invalidRequest = Utility.CheckUserImpersonatedAuth(principal, log);
             if (invalidRequest != null)
             {
                 return invalidRequest;

--- a/src/shortenerTools/UrlClickStats/UrlClickStatsByDay.cs
+++ b/src/shortenerTools/UrlClickStats/UrlClickStatsByDay.cs
@@ -55,7 +55,7 @@ namespace Cloud5mins.Function
             UrlClickStatsRequest input;
             var result = new ClickDateList();
 
-            var invalidRequest = Utility.CatchUnauthorize(principal, log);
+            var invalidRequest = Utility.CheckUserImpersonatedAuth(principal, log);
             if (invalidRequest != null)
             {
                 return invalidRequest;

--- a/src/shortenerTools/UrlList/UrlList.cs
+++ b/src/shortenerTools/UrlList/UrlList.cs
@@ -53,7 +53,7 @@ namespace Cloud5mins.Function
 
             try
             {
-                var invalidRequest = Utility.CatchUnauthorize(principal, log);
+                var invalidRequest = Utility.CheckUserImpersonatedAuth(principal, log);
                 if (invalidRequest != null)
                 {
                     return invalidRequest;

--- a/src/shortenerTools/UrlRedirect/UrlRedirect.cs
+++ b/src/shortenerTools/UrlRedirect/UrlRedirect.cs
@@ -21,18 +21,16 @@ namespace Cloud5mins.Function
         {
             log.LogInformation($"C# HTTP trigger function processed for Url: {shortUrl}");
 
-            string redirectUrl = "https://azure.com";
-
-            if (!String.IsNullOrWhiteSpace(shortUrl))
-            {
-                var config = new ConfigurationBuilder()
+            var config = new ConfigurationBuilder()
                     .SetBasePath(context.FunctionAppDirectory)
                     .AddJsonFile("settings.json", optional: true, reloadOnChange: true)
                     .AddEnvironmentVariables()
                     .Build();
+            
+            string redirectUrl = config["defaultRedirectUrl"];
 
-                redirectUrl = config["defaultRedirectUrl"];
-
+            if (!String.IsNullOrWhiteSpace(shortUrl))
+            {
                 StorageTableHelper stgHelper = new StorageTableHelper(config["UlsDataStorage"]); 
 
                 var tempUrl = new ShortUrlEntity(string.Empty, shortUrl);

--- a/src/shortenerTools/UrlUpdate/UrlUpdate.cs
+++ b/src/shortenerTools/UrlUpdate/UrlUpdate.cs
@@ -62,7 +62,7 @@ namespace Cloud5mins.Function
 
             try
             {
-                var invalidRequest = Utility.CatchUnauthorize(principal, log);
+                var invalidRequest = Utility.CheckUserImpersonatedAuth(principal, log);
 
                 if (invalidRequest != null)
                 {

--- a/src/shortenerTools/settings.json
+++ b/src/shortenerTools/settings.json
@@ -3,9 +3,11 @@
   "Values": {
     "AzureWebJobsStorage": "",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-    "FUNCTIONS_V2_COMPATIBILITY_MODE":"true",
-    "UlsDataStorage":"",
-    "defaultRedirectUrl":"https://azure.com",
-    "customDomain":"https://c5m.ca"
+    "FUNCTIONS_V2_COMPATIBILITY_MODE": "true",
+    "UlsDataStorage": "",
+    "defaultRedirectUrl": "https://azure.com",
+    "customDomain": "https://c5m.ca",
+    "enableApiAccess": true,
+    "urlShortenApiRoleName": "Url.Shorten"
   }
 }


### PR DESCRIPTION
This PR adds the ability to use App Roles in AAD to allow an API to get an access token and make a request directly to the function to shorten a URL.

The user deploying the functions is able to decide if role based api access should be enabled on the UrlShortener using configuration values and to specify the required role to grant access to the resource.